### PR TITLE
Populate empty library.properties architectures field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Add port mappings to your router automatically
 paragraph=UPnP implementation for embedded application that allows you to add automatic port mappings (port forwarding) to your embedded applications.
 category=Communication
 url=https://github.com/ofekp/TinyUPnP
-architectures=
+architectures=esp8266
 includes=TinyUPnP.h


### PR DESCRIPTION
Empty `architectures` field causes the library's examples to appear under **File > Examples > INCOMPATIBLE**, no matter which board is selected.