### PR TITLE
Mispelling : change called method name updatePortMapping to updatePor…

### DIFF
--- a/examples/PWM_LEDServer/PWM_LEDServer.ino
+++ b/examples/PWM_LEDServer/PWM_LEDServer.ino
@@ -180,7 +180,7 @@ void loop(void) {
 
   EasyDDNS.update(300000);  // check for New IP
 
-  tinyUPnP.updatePortMapping(600000, &connectWiFi);  // 10 minutes
+  tinyUPnP.updatePortMappings(600000, &connectWiFi);  // 10 minutes
 
   server.handleClient();
 }


### PR DESCRIPTION
Playing with this lib, iI found that the demo with LED doesn't work because of a mispelling method name. addPortMappings was missing the final S.