### PR TITLE
Major Fixes

### DIFF
--- a/src/TinyUPnP.cpp
+++ b/src/TinyUPnP.cpp
@@ -23,7 +23,7 @@ IPAddress ipMulti(239, 255, 255, 250);  // multicast address for SSDP
 IPAddress connectivityTestIp(64, 233, 187, 99);  // Google
 IPAddress ipNull(0, 0, 0, 0);  // indication to update rules when the IP of the device changes
 
-char packetBuffer[UDP_TX_PACKET_MAX_SIZE];  // buffer to hold incoming packet UDP_TX_PACKET_MAX_SIZE=8192
+char packetBuffer[UPNP_UDP_TX_PACKET_MAX_SIZE];  // buffer to hold incoming packet
 char responseBuffer[UDP_TX_RESPONSE_MAX_SIZE];
 
 char body_tmp[1200];
@@ -40,8 +40,8 @@ TinyUPnP::TinyUPnP(unsigned long timeoutMs = 20000) {
     _headRuleNode = NULL;
     clearGatewayInfo(&_gwInfo);
 
-    debugPrint(F("UDP_TX_PACKET_MAX_SIZE="));
-    debugPrintln(String(UDP_TX_PACKET_MAX_SIZE));
+    debugPrint(F("UPNP_UDP_TX_PACKET_MAX_SIZE="));
+    debugPrintln(String(UPNP_UDP_TX_PACKET_MAX_SIZE));
     debugPrint(F("UDP_TX_RESPONSE_MAX_SIZE="));
     debugPrintln(String(UDP_TX_RESPONSE_MAX_SIZE));
 }
@@ -723,8 +723,8 @@ ssdpDevice* TinyUPnP::waitForUnicastResponseToMSearch(IPAddress gatewayIP) {
   
     int idx = 0;
     while (idx < packetSize) {
-        memset(packetBuffer, 0, UDP_TX_PACKET_MAX_SIZE);
-        int len = _udpClient.read(packetBuffer, UDP_TX_PACKET_MAX_SIZE);
+        memset(packetBuffer, 0, UPNP_UDP_TX_PACKET_MAX_SIZE);
+        int len = _udpClient.read(packetBuffer, UPNP_UDP_TX_PACKET_MAX_SIZE);
         if (len <= 0) {
             break;
         }

--- a/src/TinyUPnP.cpp
+++ b/src/TinyUPnP.cpp
@@ -702,7 +702,7 @@ ssdpDevice* TinyUPnP::waitForUnicastResponseToMSearch(IPAddress gatewayIP) {
         debugPrint(F("Discarded packet not originating from IGD - gatewayIP ["));
         debugPrint(gatewayIP.toString());
         debugPrint(F("] remoteIP ["));
-        debugPrint(ipMulti.toString());
+        debugPrint(remoteIP.toString());
         debugPrintln(F("]"));
         return NULL;
     }

--- a/src/TinyUPnP.cpp
+++ b/src/TinyUPnP.cpp
@@ -50,12 +50,16 @@ TinyUPnP::~TinyUPnP() {
 }
 
 void TinyUPnP::addPortMappingConfig(IPAddress ruleIP, int rulePort, String ruleProtocol, int ruleLeaseDuration, String ruleFriendlyName) {
+	addPortMappingConfig(ruleIP, rulePort, rulePort, ruleProtocol, ruleLeaseDuration, ruleFriendlyName);
+}
+
+void TinyUPnP::addPortMappingConfig(IPAddress ruleIP, int ruleInternalPort, int ruleExternalPort, String ruleProtocol, int ruleLeaseDuration, String ruleFriendlyName) {
     static int index = 0;
     upnpRule *newUpnpRule = new upnpRule();
     newUpnpRule->index = index++;
     newUpnpRule->internalAddr = (ruleIP == WiFi.localIP()) ? ipNull : ruleIP;  // for automatic IP change handling
-    newUpnpRule->internalPort = rulePort;
-    newUpnpRule->externalPort = rulePort;
+    newUpnpRule->internalPort = ruleInternalPort;
+    newUpnpRule->externalPort = ruleExternalPort;
     newUpnpRule->leaseDuration = ruleLeaseDuration;
     newUpnpRule->protocol = ruleProtocol;
     newUpnpRule->devFriendlyName = ruleFriendlyName;
@@ -460,7 +464,7 @@ boolean TinyUPnP::applyActionOnSpecificPortMapping(SOAPAction *soapAction, gatew
     strcat_P(body_tmp, PSTR(" xmlns:u=\""));
     strcat_P(body_tmp, deviceInfo->serviceTypeName.c_str());
     strcat_P(body_tmp, PSTR("\">\r\n<NewRemoteHost></NewRemoteHost>\r\n<NewExternalPort>"));
-    sprintf(integer_string, "%d", rule_ptr->internalPort);
+    sprintf(integer_string, "%d", rule_ptr->externalPort);
     strcat_P(body_tmp, integer_string);
     strcat_P(body_tmp, PSTR("</NewExternalPort>\r\n<NewProtocol>"));
     strcat_P(body_tmp, rule_ptr->protocol.c_str());
@@ -964,7 +968,7 @@ boolean TinyUPnP::addPortMappingEntry(gatewayInfo *deviceInfo, upnpRule *rule_pt
     strcpy_P(body_tmp, PSTR("<?xml version=\"1.0\"?><s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body><u:AddPortMapping xmlns:u=\""));
     strcat_P(body_tmp, deviceInfo->serviceTypeName.c_str());
     strcat_P(body_tmp, PSTR("\"><NewRemoteHost></NewRemoteHost><NewExternalPort>"));
-    sprintf(integer_string, "%d", rule_ptr->internalPort);
+    sprintf(integer_string, "%d", rule_ptr->externalPort);
     strcat_P(body_tmp, integer_string);
     strcat_P(body_tmp, PSTR("</NewExternalPort><NewProtocol>"));
     strcat_P(body_tmp, rule_ptr->protocol.c_str());

--- a/src/TinyUPnP.cpp
+++ b/src/TinyUPnP.cpp
@@ -685,6 +685,9 @@ ssdpDeviceNode* TinyUPnP::listSsdpDevices() {
 // Note: the response from the IGD is sent back as unicast to this device
 // Note: only gateway defined IGD response will be considered, the rest will be ignored
 ssdpDevice* TinyUPnP::waitForUnicastResponseToMSearch(IPAddress gatewayIP) {
+    // Flush the UDP buffer since otherwise anyone who responded first will be the only one we see
+    // and we will not see the response from the gateway router
+    _udpClient.flush();
     int packetSize = _udpClient.parsePacket();
 
     // only continue if a packet is available

--- a/src/TinyUPnP.cpp
+++ b/src/TinyUPnP.cpp
@@ -24,7 +24,7 @@ IPAddress connectivityTestIp(64, 233, 187, 99);  // Google
 IPAddress ipNull(0, 0, 0, 0);  // indication to update rules when the IP of the device changes
 
 char packetBuffer[UPNP_UDP_TX_PACKET_MAX_SIZE];  // buffer to hold incoming packet
-char responseBuffer[UDP_TX_RESPONSE_MAX_SIZE];
+char responseBuffer[UPNP_UDP_TX_RESPONSE_MAX_SIZE];
 
 char body_tmp[1200];
 char integer_string[32];
@@ -42,8 +42,8 @@ TinyUPnP::TinyUPnP(unsigned long timeoutMs = 20000) {
 
     debugPrint(F("UPNP_UDP_TX_PACKET_MAX_SIZE="));
     debugPrintln(String(UPNP_UDP_TX_PACKET_MAX_SIZE));
-    debugPrint(F("UDP_TX_RESPONSE_MAX_SIZE="));
-    debugPrintln(String(UDP_TX_RESPONSE_MAX_SIZE));
+    debugPrint(F("UPNP_UDP_TX_RESPONSE_MAX_SIZE="));
+    debugPrintln(String(UPNP_UDP_TX_RESPONSE_MAX_SIZE));
 }
 
 TinyUPnP::~TinyUPnP() {
@@ -722,7 +722,7 @@ ssdpDevice* TinyUPnP::waitForUnicastResponseToMSearch(IPAddress gatewayIP) {
     debugPrintln(F("]"));
 
     // sanity check
-    if (packetSize > UDP_TX_RESPONSE_MAX_SIZE) {
+    if (packetSize > UPNP_UDP_TX_RESPONSE_MAX_SIZE) {
         debugPrint(F("Received packet with size larged than the response buffer, cannot proceed."));
         return NULL;
     }

--- a/src/TinyUPnP.h
+++ b/src/TinyUPnP.h
@@ -129,6 +129,7 @@ class TinyUPnP
         // when the ruleIP is set to the current device IP, the IP of the rule will change if the device changes its IP
         // this makes sure the traffic will be directed to the device even if the IP chnages
         void addPortMappingConfig(IPAddress ruleIP /* can be NULL */, int rulePort, String ruleProtocol, int ruleLeaseDuration, String ruleFriendlyName);
+        void addPortMappingConfig(IPAddress ruleIP /* can be NULL */, int ruleInternalPort, int ruleExternalPort, String ruleProtocol, int ruleLeaseDuration, String ruleFriendlyName);
         portMappingResult commitPortMappings();
         portMappingResult updatePortMappings(unsigned long intervalMs, callback_function fallback = NULL /* optional */);
         boolean printAllPortMappings();

--- a/src/TinyUPnP.h
+++ b/src/TinyUPnP.h
@@ -112,10 +112,7 @@ typedef struct _ssdpDeviceNode {
 } ssdpDeviceNode;
 
 enum portMappingResult {
-    NOT_YET_ATTEMPTED, // Do not have your default value be the one you're checking for. 
-    // I have no clue why this was working for the examples.
-    // I wasn't even aware that this was an issue until I added my own enum, and the checks
-    // just started failing.
+    UNKNOWN,
     SUCCESS,  // port mapping was added
     ALREADY_MAPPED,  // the port mapping is already found in the IGD
     EMPTY_PORT_MAPPING_CONFIG,

--- a/src/TinyUPnP.h
+++ b/src/TinyUPnP.h
@@ -38,7 +38,7 @@ static const char * const deviceListSsdpAll[] = {
 
 #define MAX_NUM_OF_UPDATES_WITH_NO_EFFECT 6  // after 6 tries of updatePortMappings we will execute the more extensive addPortMapping
 
-#define UDP_TX_PACKET_MAX_SIZE 1000  // reduce max UDP packet size to conserve memory (by default UDP_TX_PACKET_MAX_SIZE=8192)
+#define UPNP_UDP_TX_PACKET_MAX_SIZE 1000  // reduce max UDP packet size to conserve memory (by default UDP_TX_PACKET_MAX_SIZE=8192)
 #define UDP_TX_RESPONSE_MAX_SIZE 8192
 
 const String UPNP_SERVICE_TYPE_TAG_NAME = "serviceType";

--- a/src/TinyUPnP.h
+++ b/src/TinyUPnP.h
@@ -112,6 +112,10 @@ typedef struct _ssdpDeviceNode {
 } ssdpDeviceNode;
 
 enum portMappingResult {
+    NOT_YET_ATTEMPTED, // Do not have your default value be the one you're checking for. 
+    // I have no clue why this was working for the examples.
+    // I wasn't even aware that this was an issue until I added my own enum, and the checks
+    // just started failing.
     SUCCESS,  // port mapping was added
     ALREADY_MAPPED,  // the port mapping is already found in the IGD
     EMPTY_PORT_MAPPING_CONFIG,

--- a/src/TinyUPnP.h
+++ b/src/TinyUPnP.h
@@ -12,7 +12,7 @@
 #include <WiFiClient.h>
 #include <limits.h>
 
-#define UPNP_DEBUG
+//#define UPNP_DEBUG // uncomment to enable debug and TinyUPnP::print<...>() outputs
 #define UPNP_SSDP_PORT 1900
 #define TCP_CONNECTION_TIMEOUT_MS 6000
 #define PORT_MAPPING_INVALID_INDEX "<errorDescription>SpecifiedArrayIndexInvalid</errorDescription>"

--- a/src/TinyUPnP.h
+++ b/src/TinyUPnP.h
@@ -39,7 +39,7 @@ static const char * const deviceListSsdpAll[] = {
 #define MAX_NUM_OF_UPDATES_WITH_NO_EFFECT 6  // after 6 tries of updatePortMappings we will execute the more extensive addPortMapping
 
 #define UPNP_UDP_TX_PACKET_MAX_SIZE 1000  // reduce max UDP packet size to conserve memory (by default UDP_TX_PACKET_MAX_SIZE=8192)
-#define UDP_TX_RESPONSE_MAX_SIZE 8192
+#define UPNP_UDP_TX_RESPONSE_MAX_SIZE 8192
 
 const String UPNP_SERVICE_TYPE_TAG_NAME = "serviceType";
 const String UPNP_SERVICE_TYPE_TAG_START = "<serviceType>";


### PR DESCRIPTION
1. This includes @ArtemPisarenko 's fork's changes since they are small but very mighty. If they wish for me to remove their changes, I will do so.
2. This includes a one-liner fix for many "Invalid Gateway" errors.
3. The discarded packet `debugPrint` was printing the wrong IP. 

`waitForUnicastResponseToMSearch()` uses `_udpClient.parsePacket()` to receive new UDP data, however, the first bit of `parsePacket` checks if there is already data in the object's `rx_buffer` . If we discarded a packet for not matching the gateway (since I have several UPnP-enabled devices in my home), the packet *still resides in the buffer*. Simply flushing it before each new check solves this issue, and allowed me to successfully use the library.

